### PR TITLE
Fixes cancellation of reverse forwards with remote port allocation

### DIFF
--- a/sshubl/actions.py
+++ b/sshubl/actions.py
@@ -116,12 +116,19 @@ class SshConnect(Thread):
 
         # re-open previous forwards (if any)
         for forward in self.forwards:
+            # infer original forwarding rule from "local" and "remote" targets
+            is_reverse = forward["is_reverse"]
+            target_1, target_2 = (
+                forward["target_remote"] if is_reverse else forward["target_local"],
+                forward["target_local"] if is_reverse else forward["target_remote"],
+            )
+
             SshForward(
                 self.view,
                 identifier,
-                forward["is_reverse"],
-                forward["orig_target_1"],
-                forward["orig_target_2"],
+                is_reverse,
+                target_1,
+                target_2,
             ).start()
 
 

--- a/sshubl/project_data.py
+++ b/sshubl/project_data.py
@@ -119,12 +119,12 @@ class SshSession:
         """
         return (
             forward_1["is_reverse"],
-            forward_1["orig_target_1"],
-            forward_1["orig_target_2"],
+            forward_1["target_local"],
+            forward_1["target_remote"],
         ) == (
             forward_2["is_reverse"],
-            forward_2["orig_target_1"],
-            forward_2["orig_target_2"],
+            forward_2["target_local"],
+            forward_2["target_remote"],
         )
 
     @classmethod
@@ -148,12 +148,23 @@ class SshSession:
                     #         "/local/mount/point": "/remote/path",
                     #     },
                     #     "forwards": [
+                    #         // we save original forward targets as OpenSSH expects them on
+                    #         // cancellation (see `SshCancelForwardCommand`)
                     #         {
-                    #             "is_reverse": false,  // is it a reverse forward
-                    #             "orig_target_1": "",  // 1st forward target ([127.1:42]:127.1:42)
-                    #             "orig_target_2": "",  // 2nd forward target (127.1:42:[127.1:42])
-                    #             "target_local": "",   // "local" target (from SSHubl PoV)
-                    #             "target_remote": "",  // "remote" target (from SSHubl PoV)
+                    #             // "-L 127.0.0.1:8888:127.0.0.1:22" would be stored as :
+                    #             "is_reverse": false,
+                    #             "orig_target_1": "127.0.0.1:8888", // 1st forward target
+                    #             "orig_target_2": "127.0.0.1:22",   // 2nd forward target
+                    #             "target_local": "127.0.0.1:8888",  // "local" forward target
+                    #             "target_remote": "127.0.0.1:22",   // "remote" forward target
+                    #         },
+                    #         {
+                    #             // "-R 127.0.0.1:0:[::1]:8888" would be stored as :
+                    #             "is_reverse": true,
+                    #             "orig_target_1": "127.0.0.1:0",
+                    #             "orig_target_2": "[::1]:8888",
+                    #             "target_local": "[::1]:8888",
+                    #             "target_remote": "127.0.0.1:4242",  // allocated by remote
                     #         },
                     #     ],
                     #     "is_up": true,

--- a/sshubl/ssh_utils.py
+++ b/sshubl/ssh_utils.py
@@ -270,8 +270,8 @@ def ssh_forward(
         )
         return None
 
-    # if port must be allocated by remote, update `target_1` to allow future forward requests to
-    # re-use the same port
+    # if port is expected to be dynamically-allocated by remote, update `target_remote` to allow
+    # future forward requests to re-use the same port
     split_target_1 = target_1.rsplit(":", maxsplit=1)
     if do_open and is_reverse and int(split_target_1[-1]) == 0:
         try:
@@ -285,7 +285,7 @@ def ssh_forward(
                 target_local,
             )
             split_target_1[-1] = str(remote_port)
-            target_1 = target_remote = ":".join(split_target_1)
+            target_remote = ":".join(split_target_1)
 
     _logger.debug(
         "successfully %s forward %s %s %s",


### PR DESCRIPTION
This patch fixes port forward cancellation (`ssh_cancel_forward` command), for reverse forwards opened with a dynamically-allocated port (by remote).