### PR TITLE
Disables spellcheck in remote terminal view (Terminus v0.3.32+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Disable spellcheck in remote terminal view (Terminus v0.3.32+)
+
 ## [0.4.0] - 2024-08-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,5 @@ ignore_missing_imports = true
 module = "sublime_plugin.*"
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "package_control.*"
-ignore_missing_imports = true
-
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Disables spellcheck in remote terminal view (Terminus v0.3.32+)

This patch replaces previous Terminus package detection by a proper
`terminus_open` lookup (actually `TerminusOpenCommand` command class).

SSHubl won't (try to) consume PackageControl API anymore, which should
result in better performance when opening a remote terminal for the
first time.

New `st_utils.get_command_class` function comes with some proper testing
(including its conditional cache feature).

As Terminus v0.3.32 was released on 15/08/2024, we expect it to be
globally rolled out before next version of SSHubl.
